### PR TITLE
Pass timeout to puppeteer page.goto call

### DIFF
--- a/bin/qunit-puppeteer.js
+++ b/bin/qunit-puppeteer.js
@@ -85,7 +85,7 @@ const puppeteer = require('puppeteer');
     }
   });
 
-  await page.goto(targetURL);
+  await page.goto(targetURL, {'timeout': timeout});
 
   await page.evaluate(() => {
     QUnit.config.testTimeout = 10000;


### PR DESCRIPTION
The [puppeteer docs](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagegotourl-options) allow passing an options object to `page.goto`. You're already taking a command line argument to specify a timeout. This passes the timeout to puppeteer so it won't timeout if a test takes longer than the default 30s.