### PR TITLE
Disable sandbox execution for linux

### DIFF
--- a/bin/qunit-puppeteer.js
+++ b/bin/qunit-puppeteer.js
@@ -11,9 +11,14 @@ const targetURL = args[0];
 const timeout = parseInt(args[1] || 300000, 10);
 
 const puppeteer = require('puppeteer');
+const os = require('os');
 
 (async () => {
-  const browser = await puppeteer.launch();
+  var puppeteer_options = {};
+  if (os.platform() === 'linux') {
+    puppeteer_options = {args: ['--no-sandbox --disable-setuid-sandbox']}
+  }
+  const browser = await puppeteer.launch(puppeteer_options);
   const page = await browser.newPage();
 
   // Attach to browser console log events, and log to node console

--- a/bin/qunit-puppeteer.js
+++ b/bin/qunit-puppeteer.js
@@ -16,7 +16,7 @@ const os = require('os');
 (async () => {
   var puppeteer_options = {};
   if (os.platform() === 'linux') {
-    puppeteer_options = {args: ['--no-sandbox --disable-setuid-sandbox']}
+    puppeteer_options = {args: ['--no-sandbox', '--disable-setuid-sandbox']}
   }
   const browser = await puppeteer.launch(puppeteer_options);
   const page = await browser.newPage();


### PR DESCRIPTION
Under some circumstances on linux puppeteer will fail to start without disabling sandboxed execution. This fixes that.