### PR TITLE
Log fixes

### DIFF
--- a/bin/qunit-puppeteer.js
+++ b/bin/qunit-puppeteer.js
@@ -26,6 +26,15 @@ const puppeteer = require('puppeteer');
   var testErrors = [];
   var assertionErrors = [];
 
+  await page.exposeFunction('harness_moduleStart', context => {
+    var skippedTests = context.tests.filter(t => t.skip).length;
+    if (skippedTests === context.tests.length) {
+      console.log(`Skipping Module: ${context.name}`);
+    } else {
+      console.log(`Running Module: ${context.name}`);
+    }
+  });
+
   await page.exposeFunction('harness_moduleDone', context => {
     if (context.failed) {
       var msg = "Module Failed: " + context.name + "\n" + testErrors.join("\n");
@@ -94,6 +103,7 @@ const puppeteer = require('puppeteer');
 
     // Cannot pass the window.harness_blah methods directly, because they are
     // automatically defined as async methods, which QUnit does not support
+    QUnit.moduleStart((context) => { window.harness_moduleStart(context); });
     QUnit.moduleDone((context) => { window.harness_moduleDone(context); });
     QUnit.testDone((context) => { window.harness_testDone(context); });
     QUnit.log((context) => { window.harness_log(context); });

--- a/bin/qunit-puppeteer.js
+++ b/bin/qunit-puppeteer.js
@@ -40,6 +40,8 @@ const puppeteer = require('puppeteer');
       testErrors.push(msg);
       assertionErrors = [];
       process.stdout.write("F");
+    } else if (context.skipped) {
+      process.stdout.write("s");
     } else {
       process.stdout.write(".");
     }

--- a/bin/qunit-puppeteer.js
+++ b/bin/qunit-puppeteer.js
@@ -19,7 +19,7 @@ const puppeteer = require('puppeteer');
   // Attach to browser console log events, and log to node console
   await page.on('console', (...params) => {
     for (let i = 0; i < params.length; ++i)
-      console.log(`${params[i]}`);
+      console.log(`${(typeof(params[i]) === 'object') ? params[i]._text : params[i]}`);
   });
 
   var moduleErrors = [];

--- a/bin/qunit-puppeteer.js
+++ b/bin/qunit-puppeteer.js
@@ -29,9 +29,9 @@ const puppeteer = require('puppeteer');
   await page.exposeFunction('harness_moduleStart', context => {
     var skippedTests = context.tests.filter(t => t.skip).length;
     if (skippedTests === context.tests.length) {
-      console.log(`Skipping Module: ${context.name}`);
+      console.log(`\x1b[4m\x1b[36mSkipping Module: ${context.name}\x1b[0m`);
     } else {
-      console.log(`Running Module: ${context.name}`);
+      console.log(`\x1b[4mRunning Module: ${context.name}\x1b[0m`);
     }
   });
 
@@ -48,11 +48,11 @@ const puppeteer = require('puppeteer');
       var msg = "  Test Failed: " + context.name + assertionErrors.join("    ");
       testErrors.push(msg);
       assertionErrors = [];
-      process.stdout.write("F");
+      process.stdout.write("\x1b[31mF\x1b[0m");
     } else if (context.skipped) {
-      process.stdout.write("s");
+      process.stdout.write("\x1b[36m.\x1b[0m");
     } else {
-      process.stdout.write(".");
+      process.stdout.write("\x1b[37m.\x1b[0m");
     }
   });
 
@@ -119,7 +119,7 @@ const puppeteer = require('puppeteer');
   }
   await wait(timeout);
 
-  console.error("Tests timed out");
+  console.error(`\x1b[33mTests timed out after ${timeout}ms\x1b[0m`);
   browser.close();
   process.exit(124);
 })().catch((error) => {

--- a/bin/qunit-puppeteer.js
+++ b/bin/qunit-puppeteer.js
@@ -109,7 +109,9 @@ const puppeteer = require('puppeteer');
     QUnit.log((context) => { window.harness_log(context); });
     QUnit.done((context) => { window.harness_done(context); });
 
-    console.log("\nRunning: " + JSON.stringify(QUnit.urlParams) + "\n");
+    if (Object.keys(QUnit.urlParams).length) {
+      console.log("\nRunning with params: " + JSON.stringify(QUnit.urlParams) + "\n");
+    }
   });
 
   function wait(ms) {


### PR DESCRIPTION
Fixed up some things to fix up logging messages during test runs, including:

* fixed console output passthrough for object params
* added support for skipped tests (using an "s" instead of a ".")
* added `moduleStart` hook for printing what module is currently running
* conditional logic to only print urlParams when present
* added color to some output