### PR TITLE
Async fix

### DIFF
--- a/bin/qunit-puppeteer.js
+++ b/bin/qunit-puppeteer.js
@@ -13,102 +13,105 @@ const timeout = parseInt(args[1] || 300000, 10);
 const puppeteer = require('puppeteer');
 
 (async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
+  try {
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
 
-  // Attach to browser console log events, and log to node console
-  await page.on('console', (...params) => {
-    for (let i = 0; i < params.length; ++i)
-      console.log(`${params[i]}`);
-  });
+    // Attach to browser console log events, and log to node console
+    await page.on('console', (...params) => {
+      for (let i = 0; i < params.length; ++i)
+        console.log(`${params[i]}`);
+    });
 
-  var moduleErrors = [];
-  var testErrors = [];
-  var assertionErrors = [];
+    var moduleErrors = [];
+    var testErrors = [];
+    var assertionErrors = [];
 
-  await page.exposeFunction('harness_moduleDone', context => {
-    if (context.failed) {
-      var msg = "Module Failed: " + context.name + "\n" + testErrors.join("\n");
-      moduleErrors.push(msg);
-      testErrors = [];
-    }
-  });
-
-  await page.exposeFunction('harness_testDone', context => {
-    if (context.failed) {
-      var msg = "  Test Failed: " + context.name + assertionErrors.join("    ");
-      testErrors.push(msg);
-      assertionErrors = [];
-      process.stdout.write("F");
-    } else {
-      process.stdout.write(".");
-    }
-  });
-
-  await page.exposeFunction('harness_log', context => {
-    if (context.result) { return; } // If success don't log
-
-    var msg = "\n    Assertion Failed:";
-    if (context.message) {
-      msg += " " + context.message;
-    }
-
-    if (context.expected) {
-      msg += "\n      Expected: " + context.expected + ", Actual: " + context.actual;
-    }
-
-    assertionErrors.push(msg);
-  });
-
-  await page.exposeFunction('harness_done', context => {
-    console.log("\n");
-
-    if (moduleErrors.length > 0) {
-      for (var idx=0; idx<moduleErrors.length; idx++) {
-        console.error(moduleErrors[idx]+"\n");
+    await page.exposeFunction('harness_moduleDone', context => {
+      if (context.failed) {
+        var msg = "Module Failed: " + context.name + "\n" + testErrors.join("\n");
+        moduleErrors.push(msg);
+        testErrors = [];
       }
-    }
+    });
 
-    var stats = [
-      "Time: " + context.runtime + "ms",
-      "Total: " + context.total,
-      "Passed: " + context.passed,
-      "Failed: " + context.failed
-    ];
-    console.log(stats.join(", "));
-    
+    await page.exposeFunction('harness_testDone', context => {
+      if (context.failed) {
+        var msg = "  Test Failed: " + context.name + assertionErrors.join("    ");
+        testErrors.push(msg);
+        assertionErrors = [];
+        process.stdout.write("F");
+      } else {
+        process.stdout.write(".");
+      }
+    });
+
+    await page.exposeFunction('harness_log', context => {
+      if (context.result) { return; } // If success don't log
+
+      var msg = "\n    Assertion Failed:";
+      if (context.message) {
+        msg += " " + context.message;
+      }
+
+      if (context.expected) {
+        msg += "\n      Expected: " + context.expected + ", Actual: " + context.actual;
+      }
+
+      assertionErrors.push(msg);
+    });
+
+    await page.exposeFunction('harness_done', context => {
+      console.log("\n");
+
+      if (moduleErrors.length > 0) {
+        for (var idx=0; idx<moduleErrors.length; idx++) {
+          console.error(moduleErrors[idx]+"\n");
+        }
+      }
+
+      var stats = [
+        "Time: " + context.runtime + "ms",
+        "Total: " + context.total,
+        "Passed: " + context.passed,
+        "Failed: " + context.failed
+      ];
+      console.log(stats.join(", "));
+
+      browser.close();
+      if (context.failed > 0){
+        process.exit(1);
+      }else{
+        process.exit();
+      }
+    });
+
+    await page.goto(targetURL);
+
+    await page.evaluate(() => {
+      QUnit.config.testTimeout = 10000;
+
+      // Cannot pass the window.harness_blah methods directly, because they are
+      // automatically defined as async methods, which QUnit does not support
+      QUnit.moduleDone((context) => { window.harness_moduleDone(context); });
+      QUnit.testDone((context) => { window.harness_testDone(context); });
+      QUnit.log((context) => { window.harness_log(context); });
+      QUnit.done((context) => { window.harness_done(context); });
+
+      console.log("\nRunning: " + JSON.stringify(QUnit.urlParams) + "\n");
+    });
+
+    function wait(ms) {
+      return new Promise(resolve => setTimeout(resolve, ms));
+    }
+    await wait(timeout);
+
+    console.error("Tests timed out");
     browser.close();
-    if (context.failed > 0){
-      process.exit(1);
-    }else{
-      process.exit();
-    }
-  });
+    process.exit(124);
 
-  await page.goto(targetURL);
-
-  await page.evaluate(() => {
-    QUnit.config.testTimeout = 10000;
-
-    // Cannot pass the window.harness_blah methods directly, because they are
-    // automatically defined as async methods, which QUnit does not support
-    QUnit.moduleDone((context) => { window.harness_moduleDone(context); });
-    QUnit.testDone((context) => { window.harness_testDone(context); });
-    QUnit.log((context) => { window.harness_log(context); });
-    QUnit.done((context) => { window.harness_done(context); });
-
-    console.log("\nRunning: " + JSON.stringify(QUnit.urlParams) + "\n");
-  });
-
-  function wait(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+  } catch(err) {
+    console.error('ERROR:', err);
+    process.exit(1);
   }
-  await wait(timeout);
-
-  console.error("Tests timed out");
-  browser.close();
-  process.exit(124);
-})().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+})()

--- a/bin/qunit-puppeteer.js
+++ b/bin/qunit-puppeteer.js
@@ -99,6 +99,10 @@ const puppeteer = require('puppeteer');
       QUnit.done((context) => { window.harness_done(context); });
 
       console.log("\nRunning: " + JSON.stringify(QUnit.urlParams) + "\n");
+
+      if (!QUnit.config.autostart) {
+        QUnit.start();
+      }
     });
 
     function wait(ms) {


### PR DESCRIPTION
There was an issue with unhandled rejected Promises because th primary `async` function did not return a Promise. This PR adds a `try...catch` block inside the `async` function to catch any errors generated inside an awaited Promise.

It also adds a call to `QUnit.start()` in situations where `QUnit.config.autostart` is false... I actually recommend this being the default scenario and adding a recommendation to set this inside the QUnit test page, otherwise you can get weird scenarios (I was anyway).